### PR TITLE
Ability to pass a custom EventLoop in Relay client constructor

### DIFF
--- a/examples/relay.php
+++ b/examples/relay.php
@@ -2,6 +2,7 @@
 error_reporting(E_ALL);
 
 require dirname(__FILE__) . '/../vendor/autoload.php';
+$loop = React\EventLoop\Factory::create();
 
 $space_url = isset($_ENV['HOST']) ? $_ENV['HOST'] : '';
 $project = isset($_ENV['PROJECT']) ? $_ENV['PROJECT'] : '';
@@ -13,7 +14,8 @@ if (empty($project) || empty($token)) {
 $client = new SignalWire\Relay\Client(array(
   "host" => $space_url,
   "project" => $project,
-  "token" => $token
+  "token" => $token,
+  "eventLoop" => $loop
 ));
 
 $client->on('signalwire.socket.open', function($session) {
@@ -26,8 +28,12 @@ $client->on('signalwire.socket.close', function($session) {
   echo PHP_EOL . "signalwire.socket.close" . PHP_EOL;
 });
 
-$client->on('signalwire.ready', function($session) {
+$client->on('signalwire.ready', function($session) use ($loop) {
   echo PHP_EOL . "signalwire.ready" . PHP_EOL;
+
+  $loop->addTimer(3, function () {
+    echo PHP_EOL . "I've been stopped for 3 seconds without block the process" . PHP_EOL;
+  });
 
   // Test onInbound
   $session->calling->onInbound('home', function($call) use ($session) {

--- a/src/Relay/Client.php
+++ b/src/Relay/Client.php
@@ -53,6 +53,12 @@ class Client {
   public $connection;
 
   /**
+   * EventLoop to use in WebSocket client
+   * @var React\EventLoop
+   */
+  public $eventLoop = null;
+
+  /**
    * Relay Calling service
    * @var SignalWire\Relay\Service\Calling
    */
@@ -86,6 +92,9 @@ class Client {
     $this->host = $options['host'];
     $this->project = $options['project'];
     $this->token = $options['token'];
+    if (isset($options['eventLoop']) && $options['eventLoop'] instanceof \React\EventLoop\LoopInterface) {
+      $this->eventLoop = $options['eventLoop'];
+    }
 
     $this->uuid = Uuid::uuid4()->toString();
     $this->connection = new Connection($this);

--- a/src/Relay/Connection.php
+++ b/src/Relay/Connection.php
@@ -13,7 +13,7 @@ class Connection {
 
   public function connect() {
     $host = \SignalWire\checkWebSocketHost($this->client->host);
-    \Ratchet\Client\connect($host)->then(
+    \Ratchet\Client\connect($host, [], [], $this->client->eventLoop)->then(
       array($this, "onConnectSuccess"),
       array($this, "onConnectError")
     );


### PR DESCRIPTION
`$eventLoop` defaulted to NULL so Pawel will use the default one.

Close #32 