### PR TITLE
Default host to relay.signalwire.com

### DIFF
--- a/src/Relay/Client.php
+++ b/src/Relay/Client.php
@@ -20,7 +20,7 @@ class Client {
    * SignalWire Space Url
    * @var String
    */
-  public $host;
+  public $host = 'relay.signalwire.com';
 
   /**
    * SignalWire project
@@ -89,9 +89,15 @@ class Client {
   private $_subscriptions = array();
 
   public function __construct(Array $options) {
-    $this->host = $options['host'];
-    $this->project = $options['project'];
-    $this->token = $options['token'];
+    if (isset($options['host'])) {
+      $this->host = $options['host'];
+    }
+    if (isset($options['project']) && isset($options['token'])) {
+      $this->project = $options['project'];
+      $this->token = $options['token'];
+    } else {
+      throw new \Exception("Project and Token are required.");
+    }
     if (isset($options['eventLoop']) && $options['eventLoop'] instanceof \React\EventLoop\LoopInterface) {
       $this->eventLoop = $options['eventLoop'];
     }

--- a/src/Relay/Connection.php
+++ b/src/Relay/Connection.php
@@ -19,6 +19,7 @@ class Connection {
 
   public function connect() {
     $host = \SignalWire\checkWebSocketHost($this->client->host);
+    Log::debug("Connecting to: $host");
     \Ratchet\Client\connect($host, [], [], $this->client->eventLoop)->done([$this, "onConnectSuccess"], [$this, "onConnectError"]);
   }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -27,6 +27,5 @@ function reduceConnectParams(Array $devices, String $defaultFrom, Int $defaultTi
 
 function checkWebSocketHost(String $host): String {
   $protocol = preg_match("/^(ws|wss):\/\//", $host) ? '' : 'wss://';
-  $suffix = preg_match("/\.signalwire\.com$/", $host) ? ':443/api/relay/wss' : '';
-  return $protocol . $host . $suffix;
+  return $protocol . $host;
 }

--- a/tests/functionsTest.php
+++ b/tests/functionsTest.php
@@ -168,8 +168,8 @@ class FunctionsTest extends TestCase
 
   public function testCheckWebSocketHost(): void {
     $this->assertEquals(\SignalWire\checkWebSocketHost('ws://test.com'), 'ws://test.com');
-    $this->assertEquals(\SignalWire\checkWebSocketHost('example.signalwire.com'), 'wss://example.signalwire.com:443/api/relay/wss');
-    $this->assertEquals(\SignalWire\checkWebSocketHost('ws://example.signalwire.com'), 'ws://example.signalwire.com:443/api/relay/wss');
+    $this->assertEquals(\SignalWire\checkWebSocketHost('example.signalwire.com'), 'wss://example.signalwire.com');
+    $this->assertEquals(\SignalWire\checkWebSocketHost('ws://example.signalwire.com'), 'ws://example.signalwire.com');
     $this->assertEquals(\SignalWire\checkWebSocketHost('example.sw.com'), 'wss://example.sw.com');
   }
 }


### PR DESCRIPTION
Host default to `relay.signalwire.com` and throw error if project or token are missing.