### PR TITLE
call.receive with multiple contexts

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -61,7 +61,7 @@ class Handler {
     $event = self::_cleanEventName($evt, $uniqueId);
     if (isset(self::$queue[$event])) {
       foreach (self::$queue[$event] as $callable){
-        call_user_func_array($callable, [$params]);
+        $callable($params);
       }
     }
     return true;

--- a/src/Relay/Client.php
+++ b/src/Relay/Client.php
@@ -143,11 +143,11 @@ class Client {
   public function _onSocketOpen() {
     $this->_idle = false;
     $bladeConnect = new Connect($this->project, $this->token, $this->sessionid);
-    $this->execute($bladeConnect)->then(function($result) {
+    $this->execute($bladeConnect)->done(function($result) {
       $this->_autoReconnect = true;
       $this->sessionid = $result->sessionid;
       $this->nodeid = $result->nodeid;
-      Setup::protocol($this)->then(function(String $protocol) {
+      Setup::protocol($this)->done(function(String $protocol) {
         $this->relayProtocol = $protocol;
         $this->_emptyExecuteQueue();
         Handler::trigger(Events::Ready, $this, $this->uuid);

--- a/src/Relay/Connection.php
+++ b/src/Relay/Connection.php
@@ -25,7 +25,7 @@ class Connection {
       function(\Ratchet\Client\WebSocket $webSocket) {
         $this->_ws = $webSocket;
         $this->_ws->on('message', function($msg) {
-          Log::debug("RECV " . str_replace(' ', '', $msg->getPayload()));
+          Log::debug("RECV " . $msg->getPayload());
           $obj = json_decode($msg->getPayload());
           if (!is_object($obj) || !isset($obj->id)) {
             return;

--- a/src/Relay/Consumer.php
+++ b/src/Relay/Consumer.php
@@ -105,12 +105,8 @@ abstract class Consumer {
         echo PHP_EOL . $error->getTraceAsString() . PHP_EOL;
       }
     });
-    $promises = [];
-    foreach ((array)$this->contexts as $context) {
-      $promises[] = $this->client->calling->onInbound($context, $callback);
-    }
-    $results = yield $promises;
-    return $results;
+
+    yield $this->client->calling->onInbound((array)$this->contexts, $callback);
   }
 
   private function _checkProjectAndToken() {

--- a/src/Relay/Consumer.php
+++ b/src/Relay/Consumer.php
@@ -14,7 +14,7 @@ abstract class Consumer {
    * SignalWire Space Url
    * @var String
    */
-  public $spaceUrl;
+  public $host;
 
   /**
    * SignalWire project
@@ -68,7 +68,7 @@ abstract class Consumer {
 
   public function _init(): Coroutine {
     $this->client = new Client([
-      'host' => $this->spaceUrl,
+      'host' => $this->host,
       'project' => $this->project,
       'token' => $this->token,
       'eventLoop' => yield \Recoil\Recoil::eventLoop()


### PR DESCRIPTION
Force calling.onInbound to send contexts as an array of strings and simplify Consumer code.

Plus some minor fixes like `$spaceUrl` normalized with `$host` in Consumer