### PR TITLE
Relay Calling Tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Create your own Relay Tasks and enable `onTask` method on RelayConsumer to receive/handle them.
 - Methods to start a detector on a Call: `detect`, `detectAsync`, `detectMachine`, `detectMachineAsync`, `detectFax`, `detectFaxAsync`, `detectDigit`, `detectDigitAsync`
+- Methods to tap media in a Call: `tap` and `tapAsync`
 
 ## [2.0.0] - 2019-07-16
 ### Added

--- a/src/Relay/BroadcastHandler.php
+++ b/src/Relay/BroadcastHandler.php
@@ -36,6 +36,7 @@ class BroadcastHandler {
       case CallNotification::Collect:
       case CallNotification::Fax:
       case CallNotification::Detect:
+      case CallNotification::Tap:
         $client->getCalling()->notificationHandler($params);
         break;
       default:

--- a/src/Relay/Calling/Actions/TapAction.php
+++ b/src/Relay/Calling/Actions/TapAction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SignalWire\Relay\Calling\Actions;
+
+use SignalWire\Relay\Calling\Results\TapResult;
+
+class TapAction extends BaseAction {
+
+  public function getResult() {
+    return new TapResult($this->component);
+  }
+
+  public function getSourceDevice() {
+    return $this->component->getSourceDevice();
+  }
+
+  public function stop() {
+    return $this->component->stop();
+  }
+
+}

--- a/src/Relay/Calling/Call.php
+++ b/src/Relay/Calling/Call.php
@@ -561,6 +561,11 @@ class Call {
     }
   }
 
+  public function _tapChange($params) {
+    $this->_notifyComponents(Notification::Tap, $params->control_id, $params);
+    $this->_dispatchCallback("tap.$params->state", $params);
+  }
+
   private function _dispatchCallback(string $key, ...$params) {
     if (isset($this->_cbQueue[$key]) && is_callable($this->_cbQueue[$key])) {
       call_user_func($this->_cbQueue[$key], $this, ...$params);

--- a/src/Relay/Calling/Call.php
+++ b/src/Relay/Calling/Call.php
@@ -467,6 +467,24 @@ class Call {
     return $this->detectAsync(DetectType::Digit, $params, $timeout);
   }
 
+  public function tap(Array $tap, Array $device) {
+    $component = new Components\Tap($this, $tap, $device);
+    $this->_addComponent($component);
+
+    return $component->_waitFor(TapState::Finished)->then(function() use (&$component) {
+      return new Results\TapResult($component);
+    });
+  }
+
+  public function tapAsync(Array $tap, Array $device) {
+    $component = new Components\Tap($this, $tap, $device);
+    $this->_addComponent($component);
+
+    return $component->execute()->then(function() use (&$component) {
+      return new Actions\TapAction($component);
+    });
+  }
+
   public function on(String $event, Callable $fn) {
     $this->_cbQueue[$event] = $fn;
     return $this;

--- a/src/Relay/Calling/Call.php
+++ b/src/Relay/Calling/Call.php
@@ -468,7 +468,8 @@ class Call {
   }
 
   public function tap(Array $tap, Array $device) {
-    $component = new Components\Tap($this, $tap, $device);
+    list($_tap, $_device) = $this->_prepareTapParams($tap, $device);
+    $component = new Components\Tap($this, $_tap, $_device);
     $this->_addComponent($component);
 
     return $component->_waitFor(TapState::Finished)->then(function() use (&$component) {
@@ -477,7 +478,8 @@ class Call {
   }
 
   public function tapAsync(Array $tap, Array $device) {
-    $component = new Components\Tap($this, $tap, $device);
+    list($_tap, $_device) = $this->_prepareTapParams($tap, $device);
+    $component = new Components\Tap($this, $_tap, $_device);
     $this->_addComponent($component);
 
     return $component->execute()->then(function() use (&$component) {
@@ -611,5 +613,17 @@ class Call {
         $component->terminate($params);
       }
     }
+  }
+
+  private function _prepareTapParams(array $tap, array $device) {
+    $tapType = isset($tap['type']) ? $tap['type'] : 'audio';
+    unset($tap['type']);
+    $_tap = ['type' => $tapType, 'params' => $tap];
+
+    $deviceType = isset($device['type']) ? $device['type'] : null;
+    unset($device['type']);
+    $_device = ['type' => $deviceType, 'params' => $device];
+
+    return [$_tap, $_device];
   }
 }

--- a/src/Relay/Calling/Calling.php
+++ b/src/Relay/Calling/Calling.php
@@ -33,6 +33,9 @@ class Calling extends \SignalWire\Relay\BaseRelay {
       case Notification::Detect:
         $this->_onDetect($notification->params);
         break;
+      case Notification::Tap:
+        $this->_onTap($notification->params);
+        break;
       case Notification::Receive:
         $call = new Call($this, $notification->params);
         Handler::trigger($this->client->relayProtocol, $call, $this->_prefixCtx($call->context));
@@ -155,6 +158,13 @@ class Calling extends \SignalWire\Relay\BaseRelay {
     $call = $this->getCallById($params->call_id);
     if ($call) {
       $call->_detectChange($params);
+    }
+  }
+
+  private function _onTap($params) {
+    $call = $this->getCallById($params->call_id);
+    if ($call) {
+      $call->_tapChange($params);
     }
   }
 

--- a/src/Relay/Calling/Components/Tap.php
+++ b/src/Relay/Calling/Components/Tap.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace SignalWire\Relay\Calling\Components;
+
+use SignalWire\Relay\Calling\Call;
+use SignalWire\Relay\Calling\TapState;
+use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Event;
+
+class Tap extends Controllable {
+  public $eventType = Notification::Tap;
+  public $tap;
+  public $device;
+
+  private $_tap;
+  private $_device;
+
+  public function __construct(Call $call, Array $tap, Array $device) {
+    parent::__construct($call);
+
+    $this->_tap = $tap;
+    $this->_device = $device;
+  }
+
+  public function method() {
+    return 'call.tap';
+  }
+
+  public function payload() {
+    $this->_tap['params'] = (object) $this->_tap['params'];
+    $this->_device['params'] = (object) $this->_device['params'];
+    return [
+      'node_id' => $this->call->nodeId,
+      'call_id' => $this->call->id,
+      'control_id' => $this->controlId,
+      'tap' => $this->_tap,
+      'device' => $this->_device
+    ];
+  }
+
+  public function getSourceDevice() {
+    if ($this->_executeResult && isset($this->_executeResult->source_device)) {
+      return $this->_executeResult->source_device;
+    }
+    return null;
+  }
+
+  public function notificationHandler($params) {
+    $this->tap = $params->tap;
+    $this->device = $params->device;
+    $this->state = $params->state;
+
+    $this->completed = $this->state === TapState::Finished;
+    if ($this->completed) {
+      $this->successful = true;
+      $this->event = new Event($params->state, $params);
+    }
+
+    if ($this->_hasBlocker() && in_array($this->state, $this->_eventsToWait)) {
+      ($this->blocker->resolve)();
+    }
+  }
+}

--- a/src/Relay/Calling/Notification.php
+++ b/src/Relay/Calling/Notification.php
@@ -11,6 +11,7 @@ final class Notification {
   const Receive = 'calling.call.receive';
   const Fax = 'calling.call.fax';
   const Detect = 'calling.call.detect';
+  const Tap = 'calling.call.tap';
 
   private function __construct() {
     throw new Exception('Invalid class Notification');

--- a/src/Relay/Calling/Results/TapResult.php
+++ b/src/Relay/Calling/Results/TapResult.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SignalWire\Relay\Calling\Results;
+
+use SignalWire\Relay\Calling\Components\Tap;
+
+class TapResult extends BaseResult {
+
+  public function __construct(Tap $component) {
+    parent::__construct($component);
+  }
+
+  public function getTap() {
+    return $this->component->tap;
+  }
+
+  public function getSourceDevice() {
+    return $this->component->getSourceDevice();
+  }
+
+  public function getDestinationDevice() {
+    return $this->component->device;
+  }
+
+}

--- a/src/Relay/Calling/TapState.php
+++ b/src/Relay/Calling/TapState.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SignalWire\Relay\Calling;
+
+final class TapState {
+  const Tapping = 'tapping';
+  const Finished = 'finished';
+
+  private function __construct() {
+    throw new Exception('Invalid class TapState');
+  }
+}

--- a/tests/relay/Calling/BaseActionCase.php
+++ b/tests/relay/Calling/BaseActionCase.php
@@ -54,13 +54,17 @@ abstract class RelayCallingBaseActionCase extends TestCase
     $this->call->nodeId = 'node-id';
   }
 
-  protected function _mockSuccessResponse($msg) {
-    $success = \React\Promise\resolve(json_decode('{"result":{"code":"200","message":"message","control_id":"' . self::UUID . '"}}'));
-    $this->client->connection->expects($this->once())->method('send')->with($msg)->willReturn($success);
+  protected function _mockSuccessResponse($msg, $success = null) {
+    if (is_null($success)) {
+      $success = json_decode('{"result":{"code":"200","message":"message","control_id":"' . self::UUID . '"}}');
+    }
+    $this->client->connection->expects($this->once())->method('send')->with($msg)->willReturn(\React\Promise\resolve($success));
   }
 
-  protected function _mockFailResponse($msg) {
-    $fail = \React\Promise\reject(json_decode('{"result":{"code":"400","message":"some error","control_id":"' . self::UUID . '"}}'));
-    $this->client->connection->expects($this->once())->method('send')->with($msg)->willReturn($fail);
+  protected function _mockFailResponse($msg, $fail = null) {
+    if (is_null($fail)) {
+      $fail = json_decode('{"result":{"code":"400","message":"some error","control_id":"' . self::UUID . '"}}');
+    }
+    $this->client->connection->expects($this->once())->method('send')->with($msg)->willReturn(\React\Promise\reject($fail));
   }
 }

--- a/tests/relay/Calling/CallTapTest.php
+++ b/tests/relay/Calling/CallTapTest.php
@@ -15,8 +15,8 @@ class RelayCallingCallTapTest extends RelayCallingBaseActionCase
     self::$notificationFinished = json_decode('{"event_type":"calling.call.tap","params":{"control_id":"'.self::UUID.'","call_id":"call-id","node_id":"node-id","state":"finished","tap":{"type":"audio","params":{"direction":"listen"}},"device":{"type":"rtp","params":{"addr":"127.0.0.1","port":"1234","codec":"PCMU","ptime":"20"}}}}');
     self::$success = json_decode('{"result":{"code":"200","message":"message","control_id":"'.self::UUID.'","source_device":{"type":"rtp","params":{"addr":"10.10.10.10","port":3000,"codec":"PCMU","rate":8000}}}}');
     self::$fail = json_decode('{"result":{"code":"400","message":"some error","control_id":"'.self::UUID.'"}}');
-    self::$tap = ['type' => 'audio', 'params' => []];
-    self::$device = ['type' => 'rtp', 'params' => ['addr' => '127.0.0.1', 'port' => 1234]];
+    self::$tap = ['type' => 'audio'];
+    self::$device = ['type' => 'rtp', 'addr' => '127.0.0.1', 'port' => 1234];
   }
 
   protected function setUp() {
@@ -80,7 +80,7 @@ class RelayCallingCallTapTest extends RelayCallingBaseActionCase
         'node_id' => 'node-id',
         'control_id' => self::UUID,
         'tap' => ['type' => 'audio', 'params' => new \stdClass],
-        'device' => ['type' => 'rtp', 'params' => (object)self::$device['params']]
+        'device' => ['type' => 'rtp', 'params' => (object)['addr' => '127.0.0.1', 'port' => 1234]]
       ]
     ]);
   }

--- a/tests/relay/Calling/CallTapTest.php
+++ b/tests/relay/Calling/CallTapTest.php
@@ -1,0 +1,87 @@
+<?php
+require_once dirname(__FILE__) . '/BaseActionCase.php';
+
+use SignalWire\Messages\Execute;
+
+class RelayCallingCallTapTest extends RelayCallingBaseActionCase
+{
+  protected static $notificationFinished;
+  public static $success;
+  public static $fail;
+  protected static $tap;
+  protected static $device;
+
+  public static function setUpBeforeClass() {
+    self::$notificationFinished = json_decode('{"event_type":"calling.call.tap","params":{"control_id":"'.self::UUID.'","call_id":"call-id","node_id":"node-id","state":"finished","tap":{"type":"audio","params":{"direction":"listen"}},"device":{"type":"rtp","params":{"addr":"127.0.0.1","port":"1234","codec":"PCMU","ptime":"20"}}}}');
+    self::$success = json_decode('{"result":{"code":"200","message":"message","control_id":"'.self::UUID.'","source_device":{"type":"rtp","params":{"addr":"10.10.10.10","port":3000,"codec":"PCMU","rate":8000}}}}');
+    self::$fail = json_decode('{"result":{"code":"400","message":"some error","control_id":"'.self::UUID.'"}}');
+    self::$tap = ['type' => 'audio', 'params' => []];
+    self::$device = ['type' => 'rtp', 'params' => ['addr' => '127.0.0.1', 'port' => 1234]];
+  }
+
+  protected function setUp() {
+    parent::setUp();
+
+    $this->_setCallReady();
+  }
+
+  public function testTapSuccess(): void {
+    $msg = $this->_tapMsg();
+    $this->_mockSuccessResponse($msg, self::$success);
+    $this->call->tap(self::$tap, self::$device)->done(function($result) {
+      $this->assertInstanceOf('SignalWire\Relay\Calling\Results\TapResult', $result);
+      $this->assertTrue($result->isSuccessful());
+      $this->assertEquals($result->getTap(), json_decode('{"type":"audio","params":{"direction":"listen"}}'));
+      $this->assertEquals($result->getSourceDevice(), self::$success->result->source_device);
+      $this->assertEquals($result->getDestinationDevice(), json_decode('{"type":"rtp","params":{"addr":"127.0.0.1","port":"1234","codec":"PCMU","ptime":"20"}}'));
+      $this->assertObjectHasAttribute('tap', $result->getEvent()->payload);
+      $this->assertObjectHasAttribute('device', $result->getEvent()->payload);
+    });
+    $this->calling->notificationHandler(self::$notificationFinished);
+  }
+
+  public function testTapFail(): void {
+    $msg = $this->_tapMsg();
+    $this->_mockFailResponse($msg, self::$fail);
+    $this->call->tap(self::$tap, self::$device)->done(function($result) {
+      $this->assertInstanceOf('SignalWire\Relay\Calling\Results\TapResult', $result);
+      $this->assertFalse($result->isSuccessful());
+    });
+  }
+
+  public function testTapAsyncSuccess(): void {
+    $msg = $this->_tapMsg();
+    $this->_mockSuccessResponse($msg, self::$success);
+    $this->call->tapAsync(self::$tap, self::$device)->done(function($action) {
+      $this->assertInstanceOf('SignalWire\Relay\Calling\Actions\TapAction', $action);
+      $this->assertInstanceOf('SignalWire\Relay\Calling\Results\TapResult', $action->getResult());
+      $this->assertFalse($action->isCompleted());
+      $this->calling->notificationHandler(self::$notificationFinished);
+      $this->assertTrue($action->isCompleted());
+    });
+  }
+
+  public function testTapAsyncFail(): void {
+    $msg = $this->_tapMsg();
+    $this->_mockFailResponse($msg, self::$fail);
+    $this->call->tapAsync(self::$tap, self::$device)->done(function($action) {
+      $this->assertInstanceOf('SignalWire\Relay\Calling\Actions\TapAction', $action);
+      $this->assertTrue($action->isCompleted());
+      $this->assertEquals($action->getState(), 'failed');
+    });
+  }
+
+  private function _tapMsg() {
+    return new Execute([
+      'protocol' => 'signalwire_calling_proto',
+      'method' => 'call.tap',
+      'params' => [
+        'call_id' => 'call-id',
+        'node_id' => 'node-id',
+        'control_id' => self::UUID,
+        'tap' => ['type' => 'audio', 'params' => new \stdClass],
+        'device' => ['type' => 'rtp', 'params' => (object)self::$device['params']]
+      ]
+    ]);
+  }
+}


### PR DESCRIPTION
Last commit changed the parameters to receive a flat array without the nested `params`.

Example:

```php
<?php

$tap = [ 'type' => 'audio' ];
$device = [ 'type' => 'rtp', 'addr' => '192.168.1.1', 'port' => 1234 ];
$call->tapAsync( $tap, $device )->done(function ($tapAction) {

});
```