### PR TITLE
Review call detect parameters

### DIFF
--- a/examples/relay/detect-digits.php
+++ b/examples/relay/detect-digits.php
@@ -28,7 +28,7 @@ $client->on('signalwire.ready', function($client) {
       echo "\nDetect Update\n";
     });
 
-    $call->detectDigit('123')->done(function($result) use ($call) {
+    $call->detectDigit(['digits' => '123'])->done(function($result) use ($call) {
       print PHP_EOL . 'isSuccessful: ' . $result->isSuccessful() . PHP_EOL;
       print PHP_EOL . 'getType: ' . $result->getType() . PHP_EOL;
       print PHP_EOL . 'getResult: ' . $result->getResult() . PHP_EOL;

--- a/src/Relay/Calling/Call.php
+++ b/src/Relay/Calling/Call.php
@@ -297,8 +297,8 @@ class Call {
    * @param Array Detector params
    * @param Int Max time to run detector
    */
-  public function detect(String $type, Array $params = [], Int $timeout = null) {
-    $detect = ['type' => $type, 'params' => $params];
+  public function detect(array $params) {
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $this->_addComponent($component);
 
@@ -314,8 +314,8 @@ class Call {
    * @param Array Detector params
    * @param Int Max time to run detector
    */
-  public function detectAsync(String $type, Array $params = [], Int $timeout = null) {
-    $detect = ['type' => $type, 'params' => $params];
+  public function detectAsync(array $params) {
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $this->_addComponent($component);
 
@@ -330,8 +330,9 @@ class Call {
    * @param Array Detector params
    * @param Int Max time to run detector
    */
-  public function detectHuman(Array $params = [], Int $timeout = null) {
-    $detect = ['type' => DetectType::Machine, 'params' => $params];
+  public function detectHuman(array $params = []) {
+    $params['type'] = DetectType::Machine;
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $this->_addComponent($component);
 
@@ -347,8 +348,9 @@ class Call {
    * @param Array Detector params
    * @param Int Max time to run detector
    */
-  public function detectHumanAsync(Array $params = [], Int $timeout = null) {
-    $detect = ['type' => DetectType::Machine, 'params' => $params];
+  public function detectHumanAsync(array $params = []) {
+    $params['type'] = DetectType::Machine;
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $events = [DetectState::Human, DetectState::Error, DetectState::Finished];
     $component->setEventsToWait($events);
@@ -365,8 +367,9 @@ class Call {
    * @param Array Detector params
    * @param Int Max time to run detector
    */
-  public function detectMachine(Array $params = [], Int $timeout = null) {
-    $detect = ['type' => DetectType::Machine, 'params' => $params];
+  public function detectMachine(array $params = []) {
+    $params['type'] = DetectType::Machine;
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $this->_addComponent($component);
 
@@ -382,8 +385,9 @@ class Call {
    * @param Array Detector params
    * @param Int Max time to run detector
    */
-  public function detectMachineAsync(Array $params = [], Int $timeout = null) {
-    $detect = ['type' => DetectType::Machine, 'params' => $params];
+  public function detectMachineAsync(array $params = []) {
+    $params['type'] = DetectType::Machine;
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $events = [DetectState::Machine, DetectState::Ready, DetectState::NotReady, DetectState::Error, DetectState::Finished];
     $component->setEventsToWait($events);
@@ -400,17 +404,8 @@ class Call {
    * @param String Tone to detect 'CED' | 'CNG'
    * @param Int Max time to run detector
    */
-  public function detectFax(String $tone = null, Int $timeout = null) {
-    $params = [];
-    $faxEvents = [DetectState::CED, DetectState::CNG];
-    $events = [DetectState::Error, DetectState::Finished];
-    if ($tone && in_array($tone, $faxEvents)) {
-      $params = ['tone' => $tone];
-      array_push($events, $tone);
-    } else {
-      array_push($events, ...$faxEvents);
-    }
-    $detect = ['type' => DetectType::Fax, 'params' => $params];
+  public function detectFax(array $params = []) {
+    list($detect, $timeout, $events) = $this->_prepareDetectFaxParamsAndEvents($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $this->_addComponent($component);
 
@@ -425,17 +420,8 @@ class Call {
    * @param String Tone to detect 'CED' | 'CNG'
    * @param Int Max time to run detector
    */
-  public function detectFaxAsync(String $tone = null, Int $timeout = null) {
-    $params = [];
-    $faxEvents = [DetectState::CED, DetectState::CNG];
-    $events = [DetectState::Error, DetectState::Finished];
-    if ($tone && in_array($tone, $faxEvents)) {
-      $params = ['tone' => $tone];
-      array_push($events, $tone);
-    } else {
-      array_push($events, ...$faxEvents);
-    }
-    $detect = ['type' => DetectType::Fax, 'params' => $params];
+  public function detectFaxAsync(array $params = []) {
+    list($detect, $timeout, $events) = $this->_prepareDetectFaxParamsAndEvents($params);
     $component = new Components\Detect($this, $detect, $timeout);
     $component->setEventsToWait($events);
     $this->_addComponent($component);
@@ -451,9 +437,9 @@ class Call {
    * @param String To filter digits to detect. Default to "0123456789#*"
    * @param Int Max time to run detector
    */
-  public function detectDigit(String $digits = null, Int $timeout = null) {
-    $params = is_null($digits) ? [] : ['digits' => $digits];
-    return $this->detect(DetectType::Digit, $params, $timeout);
+  public function detectDigit(array $params = []) {
+    $params['type'] = DetectType::Digit;
+    return $this->detect($params);
   }
 
   /**
@@ -462,9 +448,9 @@ class Call {
    * @param String To filter digits to detect. Default to "0123456789#*"
    * @param Int Max time to run detector
    */
-  public function detectDigitAsync(String $digits = null, Int $timeout = null) {
-    $params = is_null($digits) ? [] : ['digits' => $digits];
-    return $this->detectAsync(DetectType::Digit, $params, $timeout);
+  public function detectDigitAsync(array $params = []) {
+    $params['type'] = DetectType::Digit;
+    return $this->detectAsync($params);
   }
 
   public function tap(Array $tap, Array $device) {
@@ -625,5 +611,31 @@ class Call {
     $_device = ['type' => $deviceType, 'params' => $device];
 
     return [$_tap, $_device];
+  }
+
+  private function _prepareDetectParams(array $params) {
+    $timeout = isset($params['timeout']) ? $params['timeout'] : null;
+    $type = isset($params['type']) ? $params['type'] : null;
+    unset($params['type'], $params['timeout']);
+    $detect = ['type' => $type, 'params' => $params];
+
+    return [$detect, $timeout];
+  }
+
+  private function _prepareDetectFaxParamsAndEvents(array $params) {
+    $params['type'] = DetectType::Fax;
+    list($detect, $timeout) = $this->_prepareDetectParams($params);
+    $faxEvents = [DetectState::CED, DetectState::CNG];
+    $events = [DetectState::Error, DetectState::Finished];
+    $tone = isset($detect['params']['tone']) ? $detect['params']['tone'] : null;
+    if ($tone && in_array($tone, $faxEvents)) {
+      $detect['params'] = ['tone' => $tone];
+      array_push($events, $tone);
+    } else {
+      $detect['params'] = [];
+      array_push($events, ...$faxEvents);
+    }
+
+    return [$detect, $timeout, $events];
   }
 }

--- a/tests/relay/Calling/CallDetectTest.php
+++ b/tests/relay/Calling/CallDetectTest.php
@@ -38,7 +38,8 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectSuccess(): void {
     $msg = $this->_detectMsg('fax');
     $this->_mockSuccessResponse($msg);
-    $this->call->detect('fax', [], 25)->done(function($result) {
+    $params = [ 'type' => 'fax', 'timeout' => 25];
+    $this->call->detect($params)->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $result);
       $this->assertTrue($result->isSuccessful());
       $this->assertEquals($result->getType(), 'fax');
@@ -53,13 +54,15 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectFail(): void {
     $msg = $this->_detectMsg('fax');
     $this->_mockFailResponse($msg);
-    $this->call->detect('fax', [], 25)->done([$this, '__detectFailCheck']);
+    $params = [ 'type' => 'fax', 'timeout' => 25];
+    $this->call->detect($params)->done([$this, '__detectFailCheck']);
   }
 
   public function testDetectAsyncSuccess(): void {
     $msg = $this->_detectMsg('fax',['tone' => 'CED'], 45);
     $this->_mockSuccessResponse($msg);
-    $this->call->detectAsync('fax', ['tone' => 'CED'], 45)->done(function($action) {
+    $params = [ 'type' => 'fax', 'timeout' => 45, 'tone' => 'CED' ];
+    $this->call->detectAsync($params)->done(function($action) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Actions\DetectAction', $action);
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $action->getResult());
       $this->assertFalse($action->isCompleted());
@@ -71,13 +74,14 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectAsyncFail(): void {
     $msg = $this->_detectMsg('fax',['tone' => 'CED'], 45);
     $this->_mockFailResponse($msg);
-    $this->call->detectAsync('fax', ['tone' => 'CED'], 45)->done([$this, '__detectAsyncFailCheck']);
+    $params = [ 'type' => 'fax', 'timeout' => 45, 'tone' => 'CED' ];
+    $this->call->detectAsync($params)->done([$this, '__detectAsyncFailCheck']);
   }
 
   public function testDetectHumanSuccess(): void {
     $msg = $this->_detectMsg('machine');
     $this->_mockSuccessResponse($msg);
-    $this->call->detectHuman([], 25)->done(function($result) {
+    $this->call->detectHuman(['timeout' => 25])->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $result);
       $this->assertTrue($result->isSuccessful());
       $this->assertEquals($result->getType(), 'machine');
@@ -86,19 +90,18 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
       $this->assertObjectHasAttribute('params', $result->getEvent()->payload);
     });
     $this->calling->notificationHandler(self::$notificationMachineHuman);
-    // $this->calling->notificationHandler(self::$notificationFaxFinished);
   }
 
   public function testDetectHumanFail(): void {
     $msg = $this->_detectMsg('machine');
     $this->_mockFailResponse($msg);
-    $this->call->detectHuman([], 25)->done([$this, '__detectFailCheck']);
+    $this->call->detectHuman(['timeout' => 25])->done([$this, '__detectFailCheck']);
   }
 
   public function testDetectHumanAsyncSuccess(): void {
     $msg = $this->_detectMsg('machine', ['initial_timeout' => 5], 45);
     $this->_mockSuccessResponse($msg);
-    $this->call->detectHumanAsync(['initial_timeout' => 5], 45)->done(function($action) {
+    $this->call->detectHumanAsync(['initial_timeout' => 5, 'timeout' => 45])->done(function($action) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Actions\DetectAction', $action);
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $action->getResult());
       $this->assertFalse($action->isCompleted());
@@ -110,14 +113,14 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectHumanAsyncFail(): void {
     $msg = $this->_detectMsg('machine', ['initial_timeout' => 5], 45);
     $this->_mockFailResponse($msg);
-    $this->call->detectHumanAsync(['initial_timeout' => 5], 45)->done([$this, '__detectAsyncFailCheck']);
+    $this->call->detectHumanAsync(['initial_timeout' => 5, 'timeout' => 45])->done([$this, '__detectAsyncFailCheck']);
   }
 
   public function testDetectMachineSuccess(): void {
     $msg = $this->_detectMsg('machine');
     $this->_mockSuccessResponse($msg);
 
-    $this->call->detectMachine([], 25)->done(function($result) {
+    $this->call->detectMachine(['timeout' => 25])->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $result);
       $this->assertTrue($result->isSuccessful());
       $this->assertEquals($result->getType(), 'machine');
@@ -132,14 +135,14 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectMachineFail(): void {
     $msg = $this->_detectMsg('machine');
     $this->_mockFailResponse($msg);
-    $this->call->detectMachine([], 25)->done([$this, '__detectFailCheck']);
+    $this->call->detectMachine(['timeout' => 25])->done([$this, '__detectFailCheck']);
   }
 
   public function testDetectMachineAsyncSuccess(): void {
     $msg = $this->_detectMsg('machine',['initial_timeout' => 4], 45);
     $this->_mockSuccessResponse($msg);
 
-    $this->call->detectMachineAsync(['initial_timeout' => 4], 45)->done(function($action) {
+    $this->call->detectMachineAsync(['initial_timeout' => 4, 'timeout' => 45])->done(function($action) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Actions\DetectAction', $action);
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $action->getResult());
       $this->assertFalse($action->isCompleted());
@@ -151,14 +154,14 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectMachineAsyncFail(): void {
     $msg = $this->_detectMsg('machine',['initial_timeout' => 4], 45);
     $this->_mockFailResponse($msg);
-    $this->call->detectMachineAsync(['initial_timeout' => 4], 45)->done([$this, '__detectAsyncFailCheck']);
+    $this->call->detectMachineAsync(['initial_timeout' => 4, 'timeout' => 45])->done([$this, '__detectAsyncFailCheck']);
   }
 
   public function testDetectDigitSuccess(): void {
     $msg = $this->_detectMsg('digit');
     $this->_mockSuccessResponse($msg);
 
-    $this->call->detectDigit(null, 25)->done(function($result) {
+    $this->call->detectDigit(['timeout' => 25])->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $result);
       $this->assertTrue($result->isSuccessful());
       $this->assertEquals($result->getType(), 'digit');
@@ -173,14 +176,14 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectDigitFail(): void {
     $msg = $this->_detectMsg('digit');
     $this->_mockFailResponse($msg);
-    $this->call->detectDigit(null, 25)->done([$this, '__detectFailCheck']);
+    $this->call->detectDigit(['timeout' => 25])->done([$this, '__detectFailCheck']);
   }
 
   public function testDetectDigitAsyncSuccess(): void {
     $msg = $this->_detectMsg('digit', ['digits' => '123'], 45);
     $this->_mockSuccessResponse($msg);
 
-    $this->call->detectDigitAsync('123', 45)->done(function($action) {
+    $this->call->detectDigitAsync(['digits' => '123', 'timeout' => 45])->done(function($action) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Actions\DetectAction', $action);
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $action->getResult());
       $this->assertFalse($action->isCompleted());
@@ -192,7 +195,7 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectDigitAsyncFail(): void {
     $msg = $this->_detectMsg('digit', ['digits' => '123'], 45);
     $this->_mockFailResponse($msg);
-    $this->call->detectDigitAsync('123', 45)->done([$this, '__detectAsyncFailCheck']);
+    $this->call->detectDigitAsync(['digits' => '123', 'timeout' => 45])->done([$this, '__detectAsyncFailCheck']);
   }
 
   /**


### PR DESCRIPTION
All `detect` and `detectX` methods get a single Array parameter.