### PR TITLE
Migrate to signalwire.receive

### DIFF
--- a/src/Relay/BaseRelay.php
+++ b/src/Relay/BaseRelay.php
@@ -1,14 +1,32 @@
 <?php
 namespace SignalWire\Relay;
 
+use SignalWire\Handler;
+
 abstract class BaseRelay {
 
   public $client;
+  protected $service;
 
   abstract function notificationHandler($notification): void;
 
   public function __construct(Client $client) {
     $this->client = $client;
+    $this->service = strtolower((new \ReflectionClass($this))->getShortName());
   }
 
+  public function registerContexts($contexts, Callable $handler) {
+    Setup::receive($this->client, $contexts)->done(function($success) use ($contexts, $handler) {
+      if ($success) {
+        foreach ((array) $contexts as $context) {
+          Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
+          print PHP_EOL . Handler::queueCount($this->client->relayProtocol, $this->_prefixCtx($context)) . PHP_EOL;
+        }
+      }
+    });
+  }
+
+  protected function _prefixCtx(String $context) {
+    return "{$this->service}.context.{$context}";
+  }
 }

--- a/src/Relay/BaseRelay.php
+++ b/src/Relay/BaseRelay.php
@@ -16,7 +16,7 @@ abstract class BaseRelay {
   }
 
   public function registerContexts($contexts, Callable $handler) {
-    Setup::receive($this->client, $contexts)->done(function($success) use ($contexts, $handler) {
+    return Setup::receive($this->client, $contexts)->then(function($success) use ($contexts, $handler) {
       if ($success) {
         foreach ((array) $contexts as $context) {
           Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));

--- a/src/Relay/BaseRelay.php
+++ b/src/Relay/BaseRelay.php
@@ -20,7 +20,6 @@ abstract class BaseRelay {
       if ($success) {
         foreach ((array) $contexts as $context) {
           Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
-          print PHP_EOL . Handler::queueCount($this->client->relayProtocol, $this->_prefixCtx($context)) . PHP_EOL;
         }
       }
     });

--- a/src/Relay/Calling/Calling.php
+++ b/src/Relay/Calling/Calling.php
@@ -1,6 +1,7 @@
 <?php
+
 namespace SignalWire\Relay\Calling;
-use SignalWire\Messages\Execute;
+
 use SignalWire\Handler;
 use SignalWire\Log;
 
@@ -52,30 +53,8 @@ class Calling extends \SignalWire\Relay\BaseRelay {
     return $call->dial();
   }
 
-  // TODO: support backward compat.
   // public function onInbound($contexts, Callable $handler) {
-  //   if (gettype($contexts) === 'string') {
-  //     $contexts = [$contexts];
-  //   }
-  //   $msg = new Execute([
-  //     'protocol' => $this->client->relayProtocol,
-  //     'method' => 'call.receive',
-  //     'params' => [ 'contexts' => $contexts ]
-  //   ]);
-  //   return $this->client->execute($msg)->done(function($response) use ($contexts, $handler) {
-  //     Log::info($response->result->message);
-  //     foreach ($contexts as $context) {
-  //       Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
-  //     }
-  //     return $response->result;
-  //   }, function ($error) {
-  //     Log::error("Calling onInbound error: {$error->message}. [code: {$error->code}]");
-  //     return $error;
-  //   });
-  // }
-
-  // private function _prefixCtx(String $context) {
-  //   return "calling.context.$context";
+  //   $this->registerContexts($contexts, $handler);
   // }
 
   public function addCall(Call $call) {

--- a/src/Relay/Calling/Calling.php
+++ b/src/Relay/Calling/Calling.php
@@ -52,30 +52,31 @@ class Calling extends \SignalWire\Relay\BaseRelay {
     return $call->dial();
   }
 
-  public function onInbound($contexts, Callable $handler) {
-    if (gettype($contexts) === 'string') {
-      $contexts = [$contexts];
-    }
-    $msg = new Execute([
-      'protocol' => $this->client->relayProtocol,
-      'method' => 'call.receive',
-      'params' => [ 'contexts' => $contexts ]
-    ]);
-    return $this->client->execute($msg)->done(function($response) use ($contexts, $handler) {
-      Log::info($response->result->message);
-      foreach ($contexts as $context) {
-        Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
-      }
-      return $response->result;
-    }, function ($error) {
-      Log::error("Calling onInbound error: {$error->message}. [code: {$error->code}]");
-      return $error;
-    });
-  }
+  // TODO: support backward compat.
+  // public function onInbound($contexts, Callable $handler) {
+  //   if (gettype($contexts) === 'string') {
+  //     $contexts = [$contexts];
+  //   }
+  //   $msg = new Execute([
+  //     'protocol' => $this->client->relayProtocol,
+  //     'method' => 'call.receive',
+  //     'params' => [ 'contexts' => $contexts ]
+  //   ]);
+  //   return $this->client->execute($msg)->done(function($response) use ($contexts, $handler) {
+  //     Log::info($response->result->message);
+  //     foreach ($contexts as $context) {
+  //       Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
+  //     }
+  //     return $response->result;
+  //   }, function ($error) {
+  //     Log::error("Calling onInbound error: {$error->message}. [code: {$error->code}]");
+  //     return $error;
+  //   });
+  // }
 
-  private function _prefixCtx(String $context) {
-    return "calling.context.$context";
-  }
+  // private function _prefixCtx(String $context) {
+  //   return "calling.context.$context";
+  // }
 
   public function addCall(Call $call) {
     array_push($this->_calls, $call);

--- a/src/Relay/Calling/Calling.php
+++ b/src/Relay/Calling/Calling.php
@@ -53,10 +53,6 @@ class Calling extends \SignalWire\Relay\BaseRelay {
     return $call->dial();
   }
 
-  // public function onInbound($contexts, Callable $handler) {
-  //   $this->registerContexts($contexts, $handler);
-  // }
-
   public function addCall(Call $call) {
     array_push($this->_calls, $call);
   }

--- a/src/Relay/Client.php
+++ b/src/Relay/Client.php
@@ -65,6 +65,12 @@ class Client {
   public $relayProtocol = null;
 
   /**
+   * Array containing the contexts this client is receiving.
+   * @var Array
+   */
+  public $contexts = [];
+
+  /**
    * Relay Calling service
    * @var SignalWire\Relay\Service\Calling
    */
@@ -90,15 +96,15 @@ class Client {
 
   /**
    * Queue of the execute messages that must be sent when the session turns up
-   * @var Boolean
+   * @var Array
    */
-  private $_executeQueue = array();
+  private $_executeQueue = [];
 
   /**
    * Hash with proto+channel this session is subscribed to
-   * @var Boolean
+   * @var Array
    */
-  private $_subscriptions = array();
+  private $_subscriptions = [];
 
   public function __construct(Array $options) {
     if (isset($options['host'])) {

--- a/src/Relay/Setup.php
+++ b/src/Relay/Setup.php
@@ -10,7 +10,7 @@ class Setup {
   const Protocol = 'signalwire';
   const Method = 'setup';
   const Channels = ['notifications'];
-  const Receive = 'call.receive'; // FIXME: change with signalwire.receive
+  const Receive = 'signalwire.receive';
 
   static function protocol(Client $client) {
     $msg = new Execute(array(

--- a/src/Relay/Setup.php
+++ b/src/Relay/Setup.php
@@ -39,7 +39,6 @@ class Setup {
     }
     $contexts = array_diff($newContexts, $client->contexts);
     if (!count($contexts)) {
-      Log::info("Already receiving these contexts.");
       return \React\Promise\resolve(true);
     }
     $msg = new Execute([

--- a/src/Relay/Setup.php
+++ b/src/Relay/Setup.php
@@ -10,6 +10,7 @@ class Setup {
   const Protocol = 'signalwire';
   const Method = 'setup';
   const Channels = ['notifications'];
+  const Receive = 'call.receive'; // FIXME: change with signalwire.receive
 
   static function protocol(Client $client) {
     $msg = new Execute(array(
@@ -27,6 +28,32 @@ class Setup {
     }, function($error) use ($client) {
       Log::error("Setup error: {$error->message}. [code: {$error->code}]");
       $client->eventLoop->stop();
+    });
+  }
+
+  static function receive(Client $client, $newContexts) {
+    $newContexts = array_filter((array)$newContexts);
+    if (!count($newContexts)) {
+      Log::error("One or more contexts are required.");
+      return \React\Promise\resolve(false);
+    }
+    $contexts = array_diff($newContexts, $client->contexts);
+    if (!count($contexts)) {
+      Log::info("Already receiving these contexts.");
+      return \React\Promise\resolve(true);
+    }
+    $msg = new Execute([
+      'protocol' => $client->relayProtocol,
+      'method' => self::Receive,
+      'params' => ['contexts' => $contexts]
+    ]);
+    return $client->execute($msg)->then(function ($response) use ($client, $contexts) {
+      $client->contexts = array_merge($client->contexts, $contexts);
+      Log::info($response->result->message);
+      return true;
+    }, function ($error) {
+      Log::error("Receive error: {$error->message}. [code: {$error->code}]");
+      return false;
     });
   }
 

--- a/src/Relay/Tasking/Tasking.php
+++ b/src/Relay/Tasking/Tasking.php
@@ -11,11 +11,11 @@ class Tasking extends \SignalWire\Relay\BaseRelay {
     Handler::trigger($this->client->relayProtocol, $notification->message, $this->_prefixCtx($notification->context));
   }
 
-  public function onTask(string $context, callable $handler) {
-    Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
-  }
+  // public function onTask(string $context, callable $handler) {
+  //   Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
+  // }
 
-  private function _prefixCtx(string $context) {
-    return "tasking.context.$context";
-  }
+  // private function _prefixCtx(string $context) {
+  //   return "tasking.context.$context";
+  // }
 }

--- a/src/Relay/Tasking/Tasking.php
+++ b/src/Relay/Tasking/Tasking.php
@@ -11,11 +11,4 @@ class Tasking extends \SignalWire\Relay\BaseRelay {
     Handler::trigger($this->client->relayProtocol, $notification->message, $this->_prefixCtx($notification->context));
   }
 
-  // public function onTask(string $context, callable $handler) {
-  //   Handler::register($this->client->relayProtocol, $handler, $this->_prefixCtx($context));
-  // }
-
-  // private function _prefixCtx(string $context) {
-  //   return "tasking.context.$context";
-  // }
 }

--- a/tests/relay/BaseRelayCase.php
+++ b/tests/relay/BaseRelayCase.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use SignalWire\Relay\Client;
+
+abstract class BaseRelayCase extends TestCase
+{
+  protected $client;
+
+  protected function setUp() {
+    $this->client = new Client(array('project' => 'project', 'token' => 'token'));
+    $this->client->relayProtocol = 'relay-proto';
+  }
+
+  public function tearDown() {
+    unset($this->client);
+  }
+
+  protected function _mockResponse($responses) {
+    $stub = $this->createMock(SignalWire\Relay\Connection::class, ['send']);
+    if (!is_array($responses)) {
+      $responses = [$responses];
+    }
+    foreach ($responses as $i => $r) {
+      $stub->expects($this->at($i))
+        ->method('send')
+        ->will($this->returnValue(\React\Promise\resolve($r)));
+    }
+
+    $this->client->connection = $stub;
+  }
+
+  protected function _mockSendNotToBeCalled() {
+    $stub = $this->createMock(SignalWire\Relay\Connection::class, ['send']);
+    $stub->expects($this->never())->method('send');
+    $this->client->connection = $stub;
+  }
+
+}

--- a/tests/relay/Calling/CallingTest.php
+++ b/tests/relay/Calling/CallingTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once dirname(__FILE__) . '/../BaseRelayCase.php';
+
+use SignalWire\Handler;
+
+class RelayCallingTest extends BaseRelayCase
+{
+  public function testRegisterContexts(): void {
+    $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"code":"200","message":"Receiving all inbound related to the requested relay contexts"}}');
+    $this->_mockResponse([$response]);
+
+    $callback = function() {};
+    $this->client->calling->registerContexts(['c1', 'c2'], $callback)->done(function() {
+      $this->assertTrue(Handler::isQueued('relay-proto', 'calling.context.c1'));
+      $this->assertTrue(Handler::isQueued('relay-proto', 'calling.context.c2'));
+    });
+  }
+}

--- a/tests/relay/SetupTest.php
+++ b/tests/relay/SetupTest.php
@@ -30,6 +30,12 @@ class RelaySetupTest extends TestCase
     $this->client->connection = $stub;
   }
 
+  private function _mockSendNotToBeCalled() {
+    $stub = $this->createMock(SignalWire\Relay\Connection::class, ['send']);
+    $stub->expects($this->never())->method('send');
+    $this->client->connection = $stub;
+  }
+
   public function testProtocolSetup(): void {
     $responseProto = json_decode('{"requester_nodeid":"ad490dc4-550a-4742-929d-b86fdf8958ef","responder_nodeid":"b0007713-071d-45f9-88aa-302d14e1251c","result":{"protocol":"signalwire_calling_proto"}}');
     $responseSubscr = json_decode('{"protocol":"signalwire_calling_proto","command":"add","subscribe_channels":["notifications"]}');
@@ -38,6 +44,64 @@ class RelaySetupTest extends TestCase
     Setup::protocol($this->client)->then(function (String $protocol) {
       $this->assertEquals('signalwire_calling_proto', $protocol);
       $this->assertArrayHasKey('signalwire_calling_protonotifications', $this->client->subscriptions);
+    });
+  }
+
+  public function testReceiveWithInvalidData(): void {
+    $this->_mockSendNotToBeCalled();
+
+    Setup::receive($this->client, '')->done(function ($success) {
+      $this->assertFalse($success);
+    });
+
+    Setup::receive($this->client, [])->done(function ($success) {
+      $this->assertFalse($success);
+    });
+
+    Setup::receive($this->client, [''])->done(function ($success) {
+      $this->assertFalse($success);
+    });
+  }
+
+  public function testReceiveWithString(): void {
+    $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"code":"200","message":"Receiving all inbound related to the requested relay contexts"}}');
+    $this->_mockResponse([$response]);
+
+    Setup::receive($this->client, 'test')->done(function ($success) {
+      $this->assertTrue($success);
+      $this->assertEquals(['test'], $this->client->contexts);
+    });
+  }
+
+  public function testReceiveWithArray(): void {
+    $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"code":"200","message":"Receiving all inbound related to the requested relay contexts"}}');
+    $this->_mockResponse([$response]);
+
+    Setup::receive($this->client, ['test1', 'test2'])->done(function ($success) {
+      $this->assertTrue($success);
+      $this->assertEquals(['test1', 'test2'], $this->client->contexts);
+    });
+  }
+
+  public function testReceiveContextAlreadyRegistered(): void {
+    $this->_mockSendNotToBeCalled();
+
+    $this->client->contexts = ['exists'];
+    Setup::receive($this->client, 'exists')->done(function ($success) {
+      $this->assertTrue($success);
+      $this->assertEquals(['exists'], $this->client->contexts);
+    });
+  }
+
+  public function testReceiveMixedContextsAlreadyRegisteredAndNot(): void {
+    $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"code":"200","message":"Receiving all inbound related to the requested relay contexts"}}');
+    $this->_mockResponse([$response]);
+
+    $this->client->contexts = ['exists'];
+
+    Setup::receive($this->client, ['exists', 'home', 'office'])->done(function ($success) {
+      $this->assertTrue($success);
+      $this->assertEquals(['exists', 'home', 'office'], $this->client->contexts);
     });
   }
 }

--- a/tests/relay/SetupTest.php
+++ b/tests/relay/SetupTest.php
@@ -1,41 +1,11 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use SignalWire\Relay\Client;
+require_once dirname(__FILE__) . '/BaseRelayCase.php';
+
 use SignalWire\Relay\Setup;
 
-class RelaySetupTest extends TestCase
+class RelaySetupTest extends BaseRelayCase
 {
-  protected $client;
-
-  protected function setUp() {
-    $this->client = new Client(array('project' => 'project', 'token' => 'token'));
-  }
-
-  public function tearDown() {
-    unset($this->client);
-  }
-
-  private function _mockResponse($responses) {
-    $stub = $this->createMock(SignalWire\Relay\Connection::class, ['send']);
-    if (!is_array($responses)) {
-      $responses = [$responses];
-    }
-    foreach ($responses as $i => $r) {
-      $stub->expects($this->at($i))
-        ->method('send')
-        ->will($this->returnValue(\React\Promise\resolve($r)));
-    }
-
-    $this->client->connection = $stub;
-  }
-
-  private function _mockSendNotToBeCalled() {
-    $stub = $this->createMock(SignalWire\Relay\Connection::class, ['send']);
-    $stub->expects($this->never())->method('send');
-    $this->client->connection = $stub;
-  }
-
   public function testProtocolSetup(): void {
     $responseProto = json_decode('{"requester_nodeid":"ad490dc4-550a-4742-929d-b86fdf8958ef","responder_nodeid":"b0007713-071d-45f9-88aa-302d14e1251c","result":{"protocol":"signalwire_calling_proto"}}');
     $responseSubscr = json_decode('{"protocol":"signalwire_calling_proto","command":"add","subscribe_channels":["notifications"]}');

--- a/tests/relay/Tasking/TaskingTest.php
+++ b/tests/relay/Tasking/TaskingTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once dirname(__FILE__) . '/../BaseRelayCase.php';
+
+use SignalWire\Handler;
+
+class RelayTaskingTest extends BaseRelayCase
+{
+  public function testRegisterContexts(): void {
+    $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"code":"200","message":"Receiving all inbound related to the requested relay contexts"}}');
+    $this->_mockResponse([$response]);
+
+    $callback = function() {};
+    $this->client->tasking->registerContexts(['home', 'office'], $callback)->done(function() {
+      $this->assertTrue(Handler::isQueued('relay-proto', 'tasking.context.home'));
+      $this->assertTrue(Handler::isQueued('relay-proto', 'tasking.context.office'));
+    });
+  }
+}


### PR DESCRIPTION
This PR move the `call.receive` request from Calling to the global namespace to be accessed by Tasking and then Messaging. 

~We have to change `call.receive` to `signalwire.receive` as soon as Blade is ready.~