### PR TITLE
Fix - Do not run the EventLoop multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Methods to start a detector on a Call: `detect`, `detectAsync`, `detectMachine`, `detectMachineAsync`, `detectFax`, `detectFaxAsync`, `detectDigit`, `detectDigitAsync`
 - Methods to tap media in a Call: `tap` and `tapAsync`
 
+### Fixed
+- Possible issue on WebSocket reconnect due to a race condition on the EventLoop.
+
 ## [2.0.0] - 2019-07-16
 ### Added
 - Add support for faxing. New call methods: `faxReceive`, `faxReceiveAsync`, `faxSend`, `faxSendAsync`.

--- a/src/Relay/Client.php
+++ b/src/Relay/Client.php
@@ -83,6 +83,12 @@ class Client {
   private $_autoReconnect = false;
 
   /**
+   * Whether the loop is running
+   * @var Boolean
+   */
+  private $_loopIsRunning = false;
+
+  /**
    * Session idle state. If true we've to save every execute and dispatch them when a new connection will be active
    * @var Boolean
    */
@@ -122,7 +128,14 @@ class Client {
   }
 
   public function connect() {
+    if (!$this->connection) {
+      return;
+    }
     $this->connection->connect();
+    if ($this->_loopIsRunning === false) {
+      $this->_loopIsRunning = true;
+      $this->eventLoop->run();
+    }
   }
 
   public function disconnect() {
@@ -132,7 +145,7 @@ class Client {
     if ($this->connection) {
       $this->connection->close();
     }
-    unset($this->connection);
+    $this->connection = null;
     $this->_executeQueue = array();
     $this->_detachListeners();
   }

--- a/src/Relay/Connection.php
+++ b/src/Relay/Connection.php
@@ -59,6 +59,8 @@ class Connection {
     if (isset($this->_ws)) {
       $this->_ws->close();
       unset($this->_ws);
+    } else {
+      $this->client->eventLoop->addTimer(0.5, [$this, 'close']);
     }
   }
 

--- a/src/Relay/Connection.php
+++ b/src/Relay/Connection.php
@@ -53,7 +53,6 @@ class Connection {
         Handler::trigger(Events::SocketError, $error, $this->client->uuid);
       }
     );
-    $this->client->eventLoop->run();
   }
 
   public function close() {


### PR DESCRIPTION
Add a check before call `eventLoop->run()`. This avoid to not run it multiple times.