### PR TITLE
Messaging send parameters tweaks

### DIFF
--- a/src/Relay/Messaging/Messaging.php
+++ b/src/Relay/Messaging/Messaging.php
@@ -25,6 +25,9 @@ class Messaging extends \SignalWire\Relay\BaseRelay {
   }
 
   public function send(Array $params) {
+    $params['from_number'] = isset($params['from']) ? $params['from'] : '';
+    $params['to_number'] = isset($params['to']) ? $params['to'] : '';
+    unset($params['from'], $params['to']);
     $msg = new Execute([
       'protocol' => $this->client->relayProtocol,
       'method' => 'messaging.send',

--- a/tests/relay/Messaging/MessagingTest.php
+++ b/tests/relay/Messaging/MessagingTest.php
@@ -43,7 +43,7 @@ class RelayMessagingTest extends BaseRelayCase
     $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"message":"Message accepted","code":"200","message_id":"2c0e265d-4597-470e-9d5d-00581e0874a2"}}');
     $this->_mockResponse([$response]);
 
-    $params = [ 'context' => 'office', 'from_number' => '8992222222', 'to_number' => '8991111111', 'body' => 'Hello' ];
+    $params = [ 'context' => 'office', 'from' => '8992222222', 'to' => '8991111111', 'body' => 'Hello' ];
     $this->client->messaging->send($params)->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Messaging\SendResult', $result);
       $this->assertTrue($result->successful);
@@ -56,7 +56,7 @@ class RelayMessagingTest extends BaseRelayCase
     $response = json_decode('{"requester_nodeid":"uuid","responder_nodeid":"uuid","result":{"message":"Some error","code":"400"}}');
     $this->_mockResponse([$response]);
 
-    $params = [ 'context' => 'office', 'from_number' => '8992222222', 'to_number' => '8991111111', 'body' => 'Hello' ];
+    $params = [ 'context' => 'office', 'from' => '8992222222', 'to' => '8991111111', 'body' => 'Hello' ];
     $this->client->messaging->send($params)->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Messaging\SendResult', $result);
       $this->assertFalse($result->successful);

--- a/tests/relay/Messaging/MessagingTest.php
+++ b/tests/relay/Messaging/MessagingTest.php
@@ -62,11 +62,5 @@ class RelayMessagingTest extends BaseRelayCase
       $this->assertFalse($result->successful);
       $this->assertFalse($result->isSuccessful());
     });
-
-    // $mock = $this->getMockBuilder(\stdClass::class)->setMethods(['foo'])->getMock();
-    // $mock->expects($this->once())->method('foo');
-    // $mock->foo();
-    // $mock->foo();
-    // $mock->foo();
   }
 }


### PR DESCRIPTION
For consistency with Calling, `messaging->send()` accepts `from` and `to` instead of raw `from_number` and `to_number`.