### PR TITLE
waitForBeep snake_case to be consistent with other params

### DIFF
--- a/src/Relay/Calling/Call.php
+++ b/src/Relay/Calling/Call.php
@@ -681,8 +681,8 @@ class Call {
   private function _prepareDetectParams(array $params) {
     $timeout = isset($params['timeout']) ? $params['timeout'] : null;
     $type = isset($params['type']) ? $params['type'] : null;
-    $waitForBeep = isset($params['waitForBeep']) ? $params['waitForBeep'] : false;
-    unset($params['type'], $params['timeout'], $params['waitForBeep']);
+    $waitForBeep = isset($params['wait_for_beep']) ? $params['wait_for_beep'] : false;
+    unset($params['type'], $params['timeout'], $params['wait_for_beep']);
     $detect = ['type' => $type, 'params' => $params];
 
     return [$detect, $timeout, $waitForBeep];

--- a/tests/relay/Calling/CallDetectTest.php
+++ b/tests/relay/Calling/CallDetectTest.php
@@ -384,7 +384,7 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectAnsweringMachineWaitingForBeep(): void {
     $msg = $this->_detectMsg('machine');
     $this->_mockSuccessResponse($msg);
-    $this->call->detectAnsweringMachine(['timeout' => 25, 'waitForBeep' => true])->done(function($result) {
+    $this->call->detectAnsweringMachine(['timeout' => 25, 'wait_for_beep' => true])->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $result);
       $this->assertTrue($result->isSuccessful());
       $this->assertEquals($result->getType(), 'machine');
@@ -401,7 +401,7 @@ class RelayCallingCallDetectTest extends RelayCallingBaseActionCase
   public function testDetectAnsweringMachineWaitingForBeepReceivingHuman(): void {
     $msg = $this->_detectMsg('machine');
     $this->_mockSuccessResponse($msg);
-    $this->call->detectAnsweringMachine(['timeout' => 25, 'waitForBeep' => true])->done(function($result) {
+    $this->call->detectAnsweringMachine(['timeout' => 25, 'wait_for_beep' => true])->done(function($result) {
       $this->assertInstanceOf('SignalWire\Relay\Calling\Results\DetectResult', $result);
       $this->assertTrue($result->isSuccessful());
       $this->assertEquals($result->getType(), 'machine');


### PR DESCRIPTION
Writing docs i noticed that all other Relay params are `snake_case` so i changed `waitForBeep` to be `wait_for_beep`.