### PR TITLE
Fix send_digits notification handler

### DIFF
--- a/examples/relay/send-digits.php
+++ b/examples/relay/send-digits.php
@@ -1,0 +1,46 @@
+<?php
+error_reporting(E_ALL);
+
+require dirname(__FILE__) . '/../../vendor/autoload.php';
+
+use Generator as Coroutine;
+use SignalWire\Relay\Consumer;
+use SignalWire\Log;
+
+class CustomConsumer extends Consumer {
+  public $project;
+  public $token;
+  public $contexts = ['home', 'office'];
+
+  public function setup() {
+    $this->project = isset($_ENV['PROJECT']) ? $_ENV['PROJECT'] : '';
+    $this->token = isset($_ENV['TOKEN']) ? $_ENV['TOKEN'] : '';
+  }
+
+  public function ready(): Coroutine {
+    $params = ['type' => 'phone', 'from' => '+1xxx', 'to' => '+1yyy'];
+    Log::info('Trying to dial: ' . $params['to']);
+    $dialResult = yield $this->client->calling->dial($params);
+    if (!$dialResult->isSuccessful()) {
+      echo "\n Error dialing \n";
+      return;
+    }
+    $call = $dialResult->getCall();
+    Log::info('Sending digits..');
+    $result = yield $call->sendDigits('1w2w3w4w5w6');
+    if ($result->isSuccessful()) {
+      Log::error('Digits sent successfully!');
+    } else {
+      Log::error('Error sending digits!');
+    }
+    yield $call->hangup();
+  }
+
+  public function teardown(): Coroutine {
+    yield;
+    echo "\n General cleanup here.. \n";
+  }
+}
+
+$x = new CustomConsumer();
+$x->run();

--- a/src/Relay/BroadcastHandler.php
+++ b/src/Relay/BroadcastHandler.php
@@ -40,6 +40,7 @@ class BroadcastHandler {
       case CallNotification::Fax:
       case CallNotification::Detect:
       case CallNotification::Tap:
+      case CallNotification::SendDigits:
         $client->getCalling()->notificationHandler($params);
         break;
       default:


### PR DESCRIPTION
Forgot the case for `SendDigits`. 

This includes examples to send digits from one consumer and detecting them from another.