### PR TITLE
Use const instead of strings in Components

### DIFF
--- a/src/Relay/Calling/Components/Answer.php
+++ b/src/Relay/Calling/Components/Answer.php
@@ -5,19 +5,17 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\CallState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Answer extends BaseComponent {
   public $eventType = Notification::State;
+  public $method = Method::Answer;
 
   public function __construct(Call $call) {
     parent::__construct($call);
 
     $this->controlId = $call->tag;
-  }
-
-  public function method() {
-    return 'calling.answer';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Await.php
+++ b/src/Relay/Calling/Components/Await.php
@@ -16,10 +16,6 @@ class Await extends BaseComponent {
     $this->controlId = $call->tag;
   }
 
-  public function method() {
-    return null;
-  }
-
   public function payload() {
     return null;
   }

--- a/src/Relay/Calling/Components/BaseComponent.php
+++ b/src/Relay/Calling/Components/BaseComponent.php
@@ -16,6 +16,9 @@ abstract class BaseComponent {
   /** Type of Relay events to handle. state|play|collect|record|connect */
   public $eventType;
 
+  /** Relay method to execute */
+  public $method = null;
+
   /** ControlId to identify the component among the notifications */
   public $controlId;
 
@@ -50,12 +53,6 @@ abstract class BaseComponent {
   }
 
   /**
-   * Relay method to execute
-   *
-   */
-  abstract function method();
-
-  /**
    * Payload sent to Relay in requests
    *
    */
@@ -73,13 +70,12 @@ abstract class BaseComponent {
       $this->terminate();
       return \React\Promise\resolve();
     }
-    $method = $this->method();
-    if ($method === null) {
+    if ($this->method === null) {
       return \React\Promise\resolve();
     }
     $msg = new Execute([
       'protocol' => $this->call->relayInstance->client->relayProtocol,
-      'method' => $method,
+      'method' => $this->method,
       'params' => $this->payload()
     ]);
 

--- a/src/Relay/Calling/Components/Connect.php
+++ b/src/Relay/Calling/Components/Connect.php
@@ -5,10 +5,12 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\ConnectState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Connect extends BaseComponent {
   public $eventType = Notification::Connect;
+  public $method = Method::Connect;
 
   private $_devices;
   private $_ringback;
@@ -19,10 +21,6 @@ class Connect extends BaseComponent {
     $this->controlId = $call->tag;
     $this->_devices = $devices;
     $this->_ringback = $ringback;
-  }
-
-  public function method() {
-    return 'calling.connect';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Controllable.php
+++ b/src/Relay/Calling/Components/Controllable.php
@@ -8,7 +8,7 @@ use SignalWire\Relay\Calling\Results\StopResult;
 abstract class Controllable extends BaseComponent {
 
   public function stop() {
-    return $this->_execute("{$this->method()}.stop")->then(function ($result) {
+    return $this->_execute("{$this->method}.stop")->then(function ($result) {
       if ($result->code !== '200') {
         $this->terminate();
       }
@@ -17,13 +17,13 @@ abstract class Controllable extends BaseComponent {
   }
 
   public function pause() {
-    return $this->_execute("{$this->method()}.pause")->then(function($result) {
+    return $this->_execute("{$this->method}.pause")->then(function($result) {
       return $result->code === '200';
     });
   }
 
   public function resume() {
-    return $this->_execute("{$this->method()}.resume")->then(function($result) {
+    return $this->_execute("{$this->method}.resume")->then(function($result) {
       return $result->code === '200';
     });
   }
@@ -31,7 +31,7 @@ abstract class Controllable extends BaseComponent {
   public function volume($value) {
     $msg = new Execute([
       'protocol' => $this->call->relayInstance->client->relayProtocol,
-      'method' => "{$this->method()}.volume",
+      'method' => "{$this->method}.volume",
       'params' => [
         'node_id' => $this->call->nodeId,
         'call_id' => $this->call->id,

--- a/src/Relay/Calling/Components/Detect.php
+++ b/src/Relay/Calling/Components/Detect.php
@@ -6,10 +6,12 @@ use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\DetectState;
 use SignalWire\Relay\Calling\DetectType;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Detect extends Controllable {
   public $eventType = Notification::Detect;
+  public $method = Method::Detect;
 
   public $type;
   public $result;
@@ -28,10 +30,6 @@ class Detect extends Controllable {
     $this->_detect = $detect;
     $this->_timeout = $timeout;
     $this->_waitForBeep = $waitForBeep;
-  }
-
-  public function method() {
-    return 'calling.detect';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Dial.php
+++ b/src/Relay/Calling/Components/Dial.php
@@ -5,19 +5,17 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\CallState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Dial extends BaseComponent {
   public $eventType = Notification::State;
+  public $method = Method::Begin;
 
   public function __construct(Call $call) {
     parent::__construct($call);
 
     $this->controlId = $call->tag;
-  }
-
-  public function method() {
-    return 'calling.begin';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Disconnect.php
+++ b/src/Relay/Calling/Components/Disconnect.php
@@ -5,19 +5,17 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\ConnectState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Disconnect extends BaseComponent {
   public $eventType = Notification::Connect;
+  public $method = Method::Disconnect;
 
   public function __construct(Call $call) {
     parent::__construct($call);
 
     $this->controlId = $call->tag;
-  }
-
-  public function method() {
-    return 'calling.disconnect';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/FaxReceive.php
+++ b/src/Relay/Calling/Components/FaxReceive.php
@@ -2,11 +2,10 @@
 
 namespace SignalWire\Relay\Calling\Components;
 
-class FaxReceive extends BaseFax {
+use SignalWire\Relay\Calling\Method;
 
-  public function method() {
-    return 'calling.receive_fax';
-  }
+class FaxReceive extends BaseFax {
+  public $method = Method::ReceiveFax;
 
   public function payload() {
     return [

--- a/src/Relay/Calling/Components/FaxSend.php
+++ b/src/Relay/Calling/Components/FaxSend.php
@@ -3,8 +3,10 @@
 namespace SignalWire\Relay\Calling\Components;
 
 use SignalWire\Relay\Calling\Call;
+use SignalWire\Relay\Calling\Method;
 
 class FaxSend extends BaseFax {
+  public $method = Method::SendFax;
   private $_document;
   private $_identity;
   private $_header;
@@ -15,10 +17,6 @@ class FaxSend extends BaseFax {
     $this->_document = $document;
     $this->_identity = $identity;
     $this->_header = $header;
-  }
-
-  public function method() {
-    return 'calling.send_fax';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Hangup.php
+++ b/src/Relay/Calling/Components/Hangup.php
@@ -5,10 +5,12 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\CallState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Hangup extends BaseComponent {
   public $eventType = Notification::State;
+  public $method = Method::End;
   public $reason;
 
   public function __construct(Call $call, String $reason) {
@@ -16,10 +18,6 @@ class Hangup extends BaseComponent {
 
     $this->controlId = $call->tag;
     $this->reason = $reason;
-  }
-
-  public function method() {
-    return 'calling.end';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Play.php
+++ b/src/Relay/Calling/Components/Play.php
@@ -5,10 +5,12 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\PlayState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Play extends Controllable {
   public $eventType = Notification::Play;
+  public $method = Method::Play;
 
   private $_play;
   private $_volume;
@@ -18,10 +20,6 @@ class Play extends Controllable {
 
     $this->_play = $play;
     $this->_volume = (float)$volume;
-  }
-
-  public function method() {
-    return 'calling.play';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Prompt.php
+++ b/src/Relay/Calling/Components/Prompt.php
@@ -5,10 +5,12 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\PromptState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Prompt extends Controllable {
   public $eventType = Notification::Collect;
+  public $method = Method::PlayAndCollect;
 
   public $type;
   public $input;
@@ -25,10 +27,6 @@ class Prompt extends Controllable {
     $this->_collect = $collect;
     $this->_play = $play;
     $this->_volume = (float)$volume;
-  }
-
-  public function method() {
-    return 'calling.play_and_collect';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Record.php
+++ b/src/Relay/Calling/Components/Record.php
@@ -5,10 +5,12 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\RecordState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Record extends Controllable {
   public $eventType = Notification::Record;
+  public $method = Method::Record;
 
   public $url;
   public $duration;
@@ -20,10 +22,6 @@ class Record extends Controllable {
     parent::__construct($call);
 
     $this->_record = $record;
-  }
-
-  public function method() {
-    return 'calling.record';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/SendDigits.php
+++ b/src/Relay/Calling/Components/SendDigits.php
@@ -5,20 +5,18 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\SendDigitsState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class SendDigits extends BaseComponent {
   public $eventType = Notification::SendDigits;
+  public $method = Method::SendDigits;
   public $digits;
 
   public function __construct(Call $call, String $digits) {
     parent::__construct($call);
 
     $this->digits = $digits;
-  }
-
-  public function method() {
-    return 'calling.send_digits';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Components/Tap.php
+++ b/src/Relay/Calling/Components/Tap.php
@@ -5,10 +5,12 @@ namespace SignalWire\Relay\Calling\Components;
 use SignalWire\Relay\Calling\Call;
 use SignalWire\Relay\Calling\TapState;
 use SignalWire\Relay\Calling\Notification;
+use SignalWire\Relay\Calling\Method;
 use SignalWire\Relay\Calling\Event;
 
 class Tap extends Controllable {
   public $eventType = Notification::Tap;
+  public $method = Method::Tap;
   public $tap;
   public $device;
 
@@ -20,10 +22,6 @@ class Tap extends Controllable {
 
     $this->_tap = $tap;
     $this->_device = $device;
-  }
-
-  public function method() {
-    return 'calling.tap';
   }
 
   public function payload() {

--- a/src/Relay/Calling/Method.php
+++ b/src/Relay/Calling/Method.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SignalWire\Relay\Calling;
+
+final class Method {
+  const Answer = 'calling.answer';
+  const Begin = 'calling.begin';
+  const Connect = 'calling.connect';
+  const End = 'calling.end';
+  const Record = 'calling.record';
+  const Play = 'calling.play';
+  const PlayAndCollect = 'calling.play_and_collect';
+  const ReceiveFax = 'calling.receive_fax';
+  const SendFax = 'calling.send_fax';
+  const Detect = 'calling.detect';
+  const Tap = 'calling.tap';
+  const SendDigits = 'calling.send_digits';
+
+  private function __construct() {
+    throw new Exception('Invalid class Method');
+  }
+}

--- a/src/Relay/Calling/Method.php
+++ b/src/Relay/Calling/Method.php
@@ -6,6 +6,7 @@ final class Method {
   const Answer = 'calling.answer';
   const Begin = 'calling.begin';
   const Connect = 'calling.connect';
+  const Disconnect = 'calling.disconnect';
   const End = 'calling.end';
   const Record = 'calling.record';
   const Play = 'calling.play';


### PR DESCRIPTION
Added new class `SignalWire\Relay\Calling\Method` to not repeat the calling.X strings everywhere.

Within each component, replace `method` function with an instance attribute.