### PR TITLE
use up-to-date php-vcr fork with patched bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "twilio/sdk": "^6.10",
+    "twilio/sdk": "6.33.0",
     "ratchet/pawl": "^0.4.1",
     "monolog/monolog": "^1.24 || ^2.0",
     "ramsey/uuid": "^3.8 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,12 @@
       "email": "open.source@signalwire.com"
     }
   ],
+  "repositories": [
+    {
+        "type": "vcs",
+        "url": "https://github.com/danieleds/php-vcr"
+    }
+  ],
   "require": {
     "php": ">=7.4",
     "twilio/sdk": "^6.10",
@@ -43,6 +49,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8",
-    "php-vcr/php-vcr": "^1.5"
+    "php-vcr/php-vcr": "dev-master"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9016dc506ae79b034f392f58c8bc65e9",
+    "content-hash": "64594e705a62e12f128635fead396b04",
     "packages": [
         {
             "name": "brick/math",
@@ -2557,41 +2557,62 @@
         },
         {
             "name": "php-vcr/php-vcr",
-            "version": "1.5.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-vcr/php-vcr.git",
-                "reference": "989fdcad482d830890757b8165127ed0183de41b"
+                "url": "https://github.com/danieleds/php-vcr.git",
+                "reference": "e3cfce4a5df080572bf55c4182a8f21e0943db7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-vcr/php-vcr/zipball/989fdcad482d830890757b8165127ed0183de41b",
-                "reference": "989fdcad482d830890757b8165127ed0183de41b",
+                "url": "https://api.github.com/repos/danieleds/php-vcr/zipball/e3cfce4a5df080572bf55c4182a8f21e0943db7d",
+                "reference": "e3cfce4a5df080572bf55c4182a8f21e0943db7d",
                 "shasum": ""
             },
             "require": {
                 "beberlei/assert": "^3.2.5",
                 "ext-curl": "*",
-                "php": ">=7.2",
-                "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0",
-                "symfony/yaml": "~2.1|^3.0|^4.0|^5.0"
+                "php": "^8.0",
+                "symfony/event-dispatcher": "^5.0",
+                "symfony/yaml": "^3.0|^4.0|^5.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16",
-                "mikey179/vfsstream": "^1.6",
-                "phpstan/phpstan": "^0.12",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "guzzlehttp/guzzle": "^7.0",
+                "mikey179/vfsstream": "^1.6.10",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^0.12.92",
                 "phpstan/phpstan-beberlei-assert": "^0.12.0",
-                "phpunit/phpunit": "^8.4.0",
-                "sebastian/version": "^1.0.3|^2.0",
+                "phpstan/phpstan-phpunit": "^0.12.22",
+                "phpunit/phpunit": "^9.5.0",
                 "thecodingmachine/phpstan-strict-rules": "^0.12"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "VCR\\": "src/VCR/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "VCR\\Tests\\": "tests"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "./vendor/bin/phpunit"
+                ],
+                "lint": [
+                    "./vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
+                ],
+                "fix": [
+                    "./vendor/bin/php-cs-fixer fix --verbose --diff"
+                ],
+                "phpstan": [
+                    "php -d memory_limit=-1 vendor/bin/phpstan analyse -c phpstan.neon --no-progress -vvv"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -2603,10 +2624,9 @@
             ],
             "description": "Record your test suite's HTTP interactions and replay them during future test runs for fast, deterministic, accurate tests.",
             "support": {
-                "issues": "https://github.com/php-vcr/php-vcr/issues",
-                "source": "https://github.com/php-vcr/php-vcr/tree/1.5.2"
+                "source": "https://github.com/danieleds/php-vcr/tree/master"
             },
-            "time": "2021-03-20T10:01:20+00:00"
+            "time": "2022-09-20T10:38:04+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4358,7 +4378,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "php-vcr/php-vcr": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64594e705a62e12f128635fead396b04",
+    "content-hash": "3246bcb9febe3a7cddffa8116a0092f9",
     "packages": [
         {
             "name": "brick/math",
@@ -2195,16 +2195,16 @@
         },
         {
             "name": "twilio/sdk",
-            "version": "6.36.1",
+            "version": "6.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twilio/twilio-php.git",
-                "reference": "68aa5dd58450d3b449c83138567ecfca93955ed9"
+                "reference": "cbe146990fe4fc2bbccf5fa45b61f8218aa99bc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/68aa5dd58450d3b449c83138567ecfca93955ed9",
-                "reference": "68aa5dd58450d3b449c83138567ecfca93955ed9",
+                "url": "https://api.github.com/repos/twilio/twilio-php/zipball/cbe146990fe4fc2bbccf5fa45b61f8218aa99bc1",
+                "reference": "cbe146990fe4fc2bbccf5fa45b61f8218aa99bc1",
                 "shasum": ""
             },
             "require": {
@@ -2212,7 +2212,8 @@
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^6.3 || ^7.0",
-                "phpunit/phpunit": ">=7.0"
+                "phpunit/phpunit": ">=4.5",
+                "theseer/phpdox": "^0.12.0"
             },
             "suggest": {
                 "guzzlehttp/guzzle": "An HTTP client to execute the API requests"
@@ -2234,7 +2235,7 @@
                 }
             ],
             "description": "A PHP wrapper for Twilio's API",
-            "homepage": "https://github.com/twilio/twilio-php",
+            "homepage": "http://github.com/twilio/twilio-php",
             "keywords": [
                 "api",
                 "sms",
@@ -2242,9 +2243,9 @@
             ],
             "support": {
                 "issues": "https://github.com/twilio/twilio-php/issues",
-                "source": "https://github.com/twilio/twilio-php/tree/6.36.1"
+                "source": "https://github.com/twilio/twilio-php/tree/6.33.0"
             },
-            "time": "2022-04-06T23:33:30+00:00"
+            "time": "2022-01-12T19:44:14+00:00"
         }
     ],
     "packages-dev": [

--- a/provisioning/Dockerfile
+++ b/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM php:8.0
 
 RUN apt-get update && apt-get install -y libxml2-dev git
 


### PR DESCRIPTION
There is a bug in PHP-VCR which I have patched separately. This PR adds the patched version as a dependency.